### PR TITLE
Recover funds to specific address with `onlyOwner`

### DIFF
--- a/contracts/ZkSyncBridgeSwapper.sol
+++ b/contracts/ZkSyncBridgeSwapper.sol
@@ -77,14 +77,14 @@ abstract contract ZkSyncBridgeSwapper is IBridgeSwapper {
     * @dev Safety method to recover ETH or ERC20 tokens that are sent to the contract by error.
     * @param _token The token to recover.
     */
-    function recoverToken(address _token) external returns (uint256 balance) {
+    function recoverToken(address _recipient, address _token) external onlyOwner returns (uint256 balance) {
         bool success;
         if (_token == ETH_TOKEN) {
             balance = address(this).balance;
-            (success, ) = owner.call{value: balance}("");
+            (success, ) = _recipient.call{value: balance}("");
         } else {
             balance = IERC20(_token).balanceOf(address(this));
-            success = IERC20(_token).transfer(owner, balance);
+            success = IERC20(_token).transfer(_recipient, balance);
         }
         require(success, "failed to recover");
     }

--- a/test/test-lido.js
+++ b/test/test-lido.js
@@ -117,7 +117,7 @@ describe("Lido Bridge Swapper", function () {
   describe("Common methods", async function () {
     it("Should recover ETH", async function () {
       const ownerBalance = await ethers.provider.getBalance(deployer.address);
-      await zap.recoverToken(ethers.constants.AddressZero);
+      await zap.recoverToken(deployer.address, ethers.constants.AddressZero);
       const ownerBalanceAfter = await ethers.provider.getBalance(deployer.address);
       expect(await ethers.provider.getBalance(zap.address)).to.equal(0);
       expect(ownerBalanceAfter).to.be.gt(ownerBalance);
@@ -125,7 +125,7 @@ describe("Lido Bridge Swapper", function () {
 
     it("Should recover ERC20", async function () {
       const ownerBalance = await wstETH.balanceOf(deployer.address);
-      await zap.recoverToken(wstETH.address);
+      await zap.recoverToken(deployer.address, wstETH.address);
       const ownerBalanceAfter = await wstETH.balanceOf(deployer.address);
       expect(await wstETH.balanceOf(zap.address)).to.equal(0);
       expect(ownerBalanceAfter).to.be.gt(ownerBalance);


### PR DESCRIPTION
Allow recovering funds to specific address but only by owner